### PR TITLE
Extended 4.15.0 behaviour to 4.15.x

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1292,7 +1292,7 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	#if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 15, 0)
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
 	, void *accel_priv
 	#else
 	, struct net_device *sb_dev


### PR DESCRIPTION
(This fixes the build when `#define LINUX_VERSION_CODE 266002` is set.)